### PR TITLE
Enforce Python < 4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ classifiers =
 
 [options]
 # https://devguide.python.org/#status-of-python-branches
-python_requires = >=3.7
+python_requires = ~=3.7
 install_requires =
     # TODO: specify versions
     PyQt5


### PR DESCRIPTION
This is minor, but it prevents tray-launcher from being mistakenly installed on Python 4 (if a Python 4 is ever released).