### PR TITLE
supports user folder with spaces

### DIFF
--- a/src/tray_launcher/core.py
+++ b/src/tray_launcher/core.py
@@ -142,7 +142,7 @@ class ChildScript:
             raise
 
         self.childScript = subprocess.Popen(
-            "\"" + self.script_path_str + "\"",
+            '"' + self.script_path_str + '"',
             encoding=self.ENCODING,
             stdout=self.outputs_file,
             stderr=self.outputs_file,


### PR DESCRIPTION
Closes #42. When the user folder contains a space, the path to `.bat` files needs to be enclosed with quotes when called in a command line.