### PR TITLE
Fix bugs

### DIFF
--- a/src/tray_launcher/gui.py
+++ b/src/tray_launcher/gui.py
@@ -774,7 +774,7 @@ def run_pythonw():
         raise
     with open(log_directory / "tray_launcher.log", "a") as launcher_log:
         subprocess.Popen(
-            "python " + str(HOME_PATH),
+            "python " + '"' + str(HOME_PATH) + '"',
             encoding="utf-8",
             creationflags=subprocess.CREATE_NO_WINDOW,
             stdout=launcher_log,

--- a/src/tray_launcher/tray_launcher_client.py
+++ b/src/tray_launcher/tray_launcher_client.py
@@ -35,10 +35,13 @@ class TrayLauncherClient(QObject):
         if not success_connect:
             return False
         else:
-            instance.client.write(bytes(instance.command + "\n", encoding="ascii"))
-            instance.client.write(bytes((instance.data + "\n"), encoding="ascii"))
-            instance.client.waitForDisconnected()
-            return True
+            try:
+                instance.client.write(bytes(instance.command + "\n", encoding="ascii"))
+                instance.client.write(bytes((instance.data + "\n"), encoding="ascii"))
+                instance.client.waitForDisconnected()
+                return True
+            except Exception as e:
+                return False
 
     def attempt_connect(self):
         """Connects to the tray launcher server."""


### PR DESCRIPTION
Fixes two things:
- When the user folder contains a space, fixes the problem that `launcher run` will not start the tray launcher.
- When starting the tray launcher, if it can make a connection to the nominal tray launcher port but cannot finish sending data, still starts the tray launcher as it indicates that the program occupying the TCP port is not a tray launcher instance. @danhuaxu I am less sure about this fix and did not test this.