### PR TITLE
Use upstream setup-nox

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Set up Python and nox
-      uses: gschaffner/setup-nox@f9b95bd3efbc64c391244db1af9640e14fc3bf72
+      uses: excitedleigh/setup-nox@v2.1.0
 
     - name: Lint
       run: |


### PR DESCRIPTION
Upstream fixed the bug that the fork fixed some time ago, but I wanted to wait for a new upstream release before switching this back.