### PR TITLE
fix venv bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,5 @@ A log for the tray-launcher and associated *.bat* scripts will be saved under `%
 If *tray-launcher* crashes, scripts started with *tray-launcher* will **not** terminate.
 
 There is an expected delay when executing `launcher run`.
+
+When the *tray-launcher* is run in a `conda` environment, scripts started with *tray-launcher* will run in the same `conda` environment. When a `venv` environment is used, scripts may not inherit the environment, and the user may need to add the activate command in a script if it should be run in the `venv`.

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,5 +47,5 @@ console_scripts =
 [flake8]
 select = BLK,I,W,E,F,C,B
 max-line-length = 100
-extend-ignore = E203
+extend-ignore = E203, W503
 max-complexity = 10

--- a/src/tray_launcher/child_script.py
+++ b/src/tray_launcher/child_script.py
@@ -12,7 +12,9 @@ class ChildScript:
     ENCODING = "utf-8"
 
     def __init__(self, pid, create_time, script_path, logging_log):
-        """Create a ChildScript instance, used in reattaching processes when the tray launcher restarts.
+        """Create a ChildScript instance.
+
+        This instance is used in reattaching processes when the tray launcher restarts.
 
         Args:
             pid: int, process id

--- a/src/tray_launcher/cli.py
+++ b/src/tray_launcher/cli.py
@@ -269,10 +269,7 @@ def run_pythonw():
             # using venv or virtualenv
             # running `python` may use the system python instead of the venv python.
             python_path = sys.executable
-            activate_path = os.path.join(
-                os.path.dirname(python_path),
-                "activate.bat"
-            )
+            activate_path = os.path.join(os.path.dirname(python_path), "activate.bat")
             activate_command = '"' + activate_path + '" && '
         else:
             # using Conda or system python.

--- a/src/tray_launcher/cli.py
+++ b/src/tray_launcher/cli.py
@@ -265,8 +265,20 @@ def run_pythonw():
         print(err + ": Failed to create new directory for tray launcher outputs")
         raise
     with open(log_directory / "tray_launcher.log", "a") as launcher_log:
+        if "VIRTUAL_ENV" in os.environ:
+            # using venv or virtualenv
+            # running `python` may use the system python instead of the venv python.
+            python_path = sys.executable
+            activate_path = os.path.join(
+                os.path.dirname(python_path),
+                "activate.bat"
+            )
+            activate_command = '"' + activate_path + '" && '
+        else:
+            # using Conda or system python.
+            activate_command = ""
         subprocess.Popen(
-            "python " + '"' + str(HOME_PATH) + '"',
+            activate_command + "python " + '"' + str(HOME_PATH) + '"',
             encoding="utf-8",
             creationflags=subprocess.CREATE_NO_WINDOW,
             stdout=launcher_log,


### PR DESCRIPTION
With `venv` on Windows (python 3.10), I cannot run tray-launcher. It turns out that `python` from `subprocess.Popen` uses the system python instead of the `venv` python. I still do not fully understand why, but a patch is attached with also explanation in the README about possible `venv` issues.

Also fixes a few lint issues and ignores `W503` (operators at the start of a line). I am not sure why these issues appear here.

@danhuaxu besides reviewing, can you install this version of tray-launcher on a computer and make sure that it still works with conda? I think it should be fine but just want to make sure.