### PR TITLE
Use stdlib subprocess args to str conversion on Windows

### DIFF
--- a/src/tray_launcher/child_script.py
+++ b/src/tray_launcher/child_script.py
@@ -71,7 +71,8 @@ class ChildScript:
         self.access_file(_t.localtime(_t.time()))
 
         self.child_script = subprocess.Popen(
-            '"' + self.script_path_str + '"',
+            # TODO: Python >= 3.8: Drop str cast (https://github.com/python/cpython/issues/76142).
+            (self.script_path_str,),
             encoding=self.ENCODING,
             stdout=self.outputs_file,
             stderr=self.outputs_file,
@@ -125,8 +126,13 @@ class ChildScript:
         """Populate the self.current_PIDs array with pids of child processes."""
         self.current_PIDs = []
         wmic_ = subprocess.run(
-            "wmic process where (ParentProcessId={}) get ProcessId".format(
-                str(self.child_script_PID)
+            (
+                "wmic",
+                "process",
+                "where",
+                f"(ParentProcessId={self.child_script_PID})",
+                "get",
+                "ProcessId",
             ),
             encoding=self.ENCODING,
             stdout=subprocess.PIPE,

--- a/src/tray_launcher/cli.py
+++ b/src/tray_launcher/cli.py
@@ -266,7 +266,7 @@ def run_pythonw():
         raise
     with open(log_directory / "tray_launcher.log", "a") as launcher_log:
         subprocess.Popen(
-            f'{sys.executable} "{HOME_PATH}"',
+            (sys.executable, HOME_PATH),
             encoding="utf-8",
             creationflags=subprocess.CREATE_NO_WINDOW,
             stdout=launcher_log,


### PR DESCRIPTION
This might fix some quoting bugs. The distinction is also more important on non-Windows platforms, if support for any of those is ever added.